### PR TITLE
feat: add `tag-actor` and `comment-method` input parameters

### DIFF
--- a/.github/examples/pr_push_stages.yaml
+++ b/.github/examples/pr_push_stages.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           command: init
           working-directory: path/to/directory
-          comment-pr: none
+          comment-pr: never
 
       - name: Check for diff
         id: check

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -54,6 +54,7 @@ jobs:
           tool: tofu
           format: true
           validate: true
+          tag-actor: on-change
 
       - name: Echo TF
         run: |

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -54,7 +54,7 @@ jobs:
           tool: tofu
           format: true
           validate: true
-          tag-actor: on-change
+          tag-actor: never
 
       - name: Echo TF
         run: |

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -54,6 +54,7 @@ jobs:
           tool: tofu
           format: true
           validate: true
+          tag-actor: never
 
       - name: Echo TF
         run: |

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -54,7 +54,7 @@ jobs:
           tool: tofu
           format: true
           validate: true
-          comment-pr: on-change
+          comment-pr: never
 
       - name: Echo TF
         run: |

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -21,10 +21,10 @@ jobs:
       matrix:
         test:
           - pass_one
-          # - pass_character_limit
+          - pass_character_limit
           - fail_data_source_error
           - fail_format_diff
-          # - fail_invalid_resource_type
+          - fail_invalid_resource_type
 
     steps:
       - name: Echo context
@@ -54,7 +54,6 @@ jobs:
           tool: tofu
           format: true
           validate: true
-          comment-pr: never
 
       - name: Echo TF
         run: |

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -21,10 +21,10 @@ jobs:
       matrix:
         test:
           - pass_one
-          - pass_character_limit
+          # - pass_character_limit
           - fail_data_source_error
           - fail_format_diff
-          - fail_invalid_resource_type
+          # - fail_invalid_resource_type
 
     steps:
       - name: Echo context

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -54,7 +54,7 @@ jobs:
           tool: tofu
           format: true
           validate: true
-          tag-actor: never
+          comment-pr: on-change
 
       - name: Echo TF
         run: |

--- a/README.md
+++ b/README.md
@@ -155,13 +155,15 @@ For each workflow run, a matrix-friendly job summary with logs is added as a fal
 | Check    | `plan-parity`       | Replace the plan file if it matches a newly-generated one to prevent stale apply (very rarely needed nowadays).</br>Default: `false` |
 | Security | `plan-encrypt`      | Encrypt plan file artifact with the given input.</br>Example: `${{ secrets.PASSPHRASE }}`                                            |
 | Security | `token`             | Specify a GitHub token.</br>Default: `${{ github.token }}`                                                                           |
-| UI       | `comment-pr`        | PR comment by: `update` existing comment, `recreate` and delete previous one, or `none`.</br>Default: `update`                       |
 | UI       | `label-pr`          | Add a PR label with the command input.</br>Default: `true`                                                                           |
+| UI       | `comment-pr`        | Add a PR comment: `always`, `on-change`, or `never`.</br>Default: `always`                                                           |
+| UI       | `comment-method`    | PR comment by: `update` existing comment or `recreate` and delete previous one.</br>Default: `update`                                |
+| UI       | `tag-actor`         | Tag the workflow triggering actor: `always`, `on-change`, or `never`.</br>Default: `always`                                          |
 | UI       | `hide-args`         | Hide comma-separated list of CLI arguments from the command input.</br>Default: `detailed-exitcode,lock,out,var=`                    |
 | UI       | `show-args`         | Show comma-separated list of CLI arguments in the command input.</br>Default: `workspace`                                            |
 </br>
 
-The default behavior of `comment-pr` is to update the existing PR comment with the latest plan output, making it easy to track changes over time through the comment's revision history.</br>
+The default behavior of `comment-method` is to update the existing PR comment with the latest plan/apply output, making it easy to track changes over time through the comment's revision history.</br>
 
 [![PR comment revision history comparing plan and apply outputs.](/.github/assets/revisions.png)](https://raw.githubusercontent.com/op5dev/tf-via-pr/refs/heads/main/.github/assets/revisions.png "View full-size image.")
 </br></br>

--- a/action.yml
+++ b/action.yml
@@ -263,6 +263,8 @@ runs:
 
     - id: post
       if: ${{ !cancelled() && steps.identifier.outcome == 'success' && contains(fromJSON('["plan", "apply", "init"]'), inputs.command) }}
+      env:
+        exitcode: ${{ steps.apply.outputs.exit_code || steps.plan.outputs.exit_code || steps.validate.outputs.exit_code || steps.workspace.outputs.exit_code || steps.initialize.outputs.exit_code || steps.format.outputs.exit_code }}
       shell: bash
       run: |
         # Post output.
@@ -335,6 +337,18 @@ runs:
           diff=""
         fi
 
+        # Set flags for creating PR comment and tagging actor.
+        create_comment=""
+        tag_actor=""
+        if [[ $exitcode -ne 0 ]]; then
+          if [[ "${{ inputs.comment-pr }}" == "on-change" ]]; then create_comment="true"; fi
+          if [[ "${{ inputs.tag-actor }}" == "on-change" ]]; then tag_actor="true"; fi
+        fi
+        if [[ "${{ inputs.comment-pr }}" == "always" ]]; then create_comment="true"; fi
+        if [[ "${{ inputs.tag-actor }}" == "always" ]]; then tag_actor="true"; fi
+        if [[ "$tag_actor" == "true" ]]; then handle="@"; else handle=""; fi
+
+        # Collate body content.
         body=$(cat <<EOTFVIAPR
         <!-- placeholder-1 -->
         \`\`\`fish
@@ -346,7 +360,7 @@ runs:
         <details><summary>${summary}</br>
 
         <!-- placeholder-4 -->
-        ###### By @${GITHUB_TRIGGERING_ACTOR} at ${{ github.event.pull_request.updated_at || github.event.head_commit.timestamp || github.event.merge_group.head_commit.timestamp }} [(view log)](${run_url}).
+        ###### By ${handle}${GITHUB_TRIGGERING_ACTOR} at ${{ github.event.pull_request.updated_at || github.event.head_commit.timestamp || github.event.merge_group.head_commit.timestamp }} [(view log)](${run_url}).
         </summary>
 
         \`\`\`${syntax}
@@ -362,19 +376,19 @@ runs:
         # Post output to job summary.
         echo "$body" >> $GITHUB_STEP_SUMMARY
 
-        # Post PR comment per ${{ inputs.comment-pr }} and if the PR number is not 0.
-        if [[ "${{ inputs.comment-pr }}" != "none" && "${{ steps.identifier.outputs.pr }}" != "0" ]]; then
+        # Post PR comment if configured and PR exists.
+        if [[ "$create_comment" == "true" && "${{ steps.identifier.outputs.pr }}" != "0" ]]; then
           # Check if the PR contains a bot comment with the same identifier.
           list_comments=$(gh api /repos/{owner}/{repo}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method GET --field per_page=100)
           bot_comment=$(echo "$list_comments" | jq --raw-output --arg identifier "${{ steps.identifier.outputs.name }}" '.[] | select(.user.type == "Bot") | select(.body | contains($identifier)) | .id' | tail -n 1)
 
           if [[ -n "$bot_comment" ]]; then
-            if [[ "${{ inputs.comment-pr }}" == "recreate" ]]; then
+            if [[ "${{ inputs.comment-method }}" == "recreate" ]]; then
               # Delete previous comment before posting a new one.
               gh api /repos/{owner}/{repo}/issues/comments/${bot_comment} --header "$GH_API" --method DELETE
               pr_comment=$(gh api /repos/{owner}/{repo}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method POST --field "body=${body}")
               echo "comment_id=$(echo "$pr_comment" | jq --raw-output '.id')" >> "$GITHUB_OUTPUT"
-            elif [[ "${{ inputs.comment-pr }}" == "update" ]]; then
+            elif [[ "${{ inputs.comment-method }}" == "update" ]]; then
               # Update existing comment.
               pr_comment=$(gh api /repos/{owner}/{repo}/issues/comments/${bot_comment} --header "$GH_API" --method PATCH --field "body=${body}")
               echo "comment_id=$(echo "$pr_comment" | jq --raw-output '.id')" >> "$GITHUB_OUTPUT"
@@ -433,9 +447,13 @@ inputs:
     default: ""
     description: "Command to run between: `plan` or `apply`. Optionally `init` for checks and outputs only (e.g., `plan`)."
     required: false
-  comment-pr:
+  comment-method:
     default: "update"
-    description: "PR comment by: `update` existing comment, `recreate` and delete previous one, or `none` (e.g., `update`)."
+    description: "PR comment by: `update` existing comment or `recreate` and delete previous one (e.g., `update`)."
+    required: false
+  comment-pr:
+    default: "always"
+    description: "Add a PR comment: `always`, `on-change`, or `never` (e.g., `always`)."
     required: false
   format:
     default: "false"
@@ -460,6 +478,10 @@ inputs:
   show-args:
     default: "workspace"
     description: "Show comma-separated arguments in the command input (e.g., `workspace`)."
+    required: false
+  tag-actor:
+    default: "always"
+    description: "Tag the workflow triggering actor: `always`, `on-change`, or `never` (e.g., `always`)."
     required: false
   token:
     default: ${{ github.token }}

--- a/tests/pass_one/main.tf
+++ b/tests/pass_one/main.tf
@@ -1,3 +1,3 @@
 resource "random_pet" "name" {
-  count = 1
+  count = 0
 }

--- a/tests/pass_one/main.tf
+++ b/tests/pass_one/main.tf
@@ -1,3 +1,3 @@
 resource "random_pet" "name" {
-  count = 0
+  count = 1
 }


### PR DESCRIPTION
Resolves #364.

https://github.com/DevSecTop/TF-via-PR/compare/v12.1.0...v13.0.0

### Breaking

#### Inputs

The `comment-pr` input was overloaded as it determined the method of PR comment (i.e., `update` or `recreate`) in addition to whether a comment should be added at all (i.e., `none`). This has been simplified such that:

|Before|After|
|---|---|
|`comment-pr: update`|`comment-method: update` (default)|
|`comment-pr: recreate`|`comment-method: recreate`|
|`comment-pr: none`|`comment-pr: never` (or `on-change`)|

#### Rename

Following an organisation rename from [DevSecTop to OP5dev](https://github.com/orgs/OP5dev/discussions/7), references to the old name may result in "Unable to resolve action" until updated to `uses: op5dev/tf-via-pr@v13`.

### Added

- #370 New `tag-actor` parameter to tag the workflow triggering actor: `always` (default), `on-change`, or `never`.
- #370 New `comment-method` parameter which supersedes `comment-pr` to choose between: `update` existing comment (default) or `recreate` and delete previous one.
- #370 Enhance `comment-pr` parameter to add a PR comment: `always` (default), `on-change`, or `never`.


### Changed

- #368 Rename references to reflect OP5dev organisation name

---

```yaml
uses: op5dev/tf-via-pr@TODO # v13.0.0
```
