### PR TITLE
fix: get pr for `issue_comment` event trigger

### DIFF
--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -2,9 +2,11 @@
 name: TF Tests
 
 on:
-  pull_request:
-    paths: [.github/workflows/tf_tests.yaml, action.yml, tests/**]
-    types: [opened, reopened, synchronize, closed]
+  issue_comment:
+
+  # pull_request:
+  #   paths: [.github/workflows/tf_tests.yaml, action.yml, tests/**]
+  #   types: [opened, reopened, synchronize, closed]
 
 jobs:
   tests:
@@ -21,10 +23,10 @@ jobs:
       matrix:
         test:
           - pass_one
-          - pass_character_limit
-          - fail_data_source_error
-          - fail_format_diff
-          - fail_invalid_resource_type
+          # - pass_character_limit
+          # - fail_data_source_error
+          # - fail_format_diff
+          # - fail_invalid_resource_type
 
     steps:
       - name: Echo context
@@ -48,8 +50,9 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
-          command: ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
-          arg-lock: ${{ github.event.pull_request.merged }}
+          command: apply # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
+          arg-auto-approve: true
+          # arg-lock: ${{ github.event.pull_request.merged }}
           working-directory: tests/${{ matrix.test }}
           tool: tofu
           format: true

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -2,11 +2,9 @@
 name: TF Tests
 
 on:
-  issue_comment:
-
-  # pull_request:
-  #   paths: [.github/workflows/tf_tests.yaml, action.yml, tests/**]
-  #   types: [opened, reopened, synchronize, closed]
+  pull_request:
+    paths: [.github/workflows/tf_tests.yaml, action.yml, tests/**]
+    types: [opened, reopened, synchronize, closed]
 
 jobs:
   tests:
@@ -23,10 +21,10 @@ jobs:
       matrix:
         test:
           - pass_one
-          # - pass_character_limit
-          # - fail_data_source_error
-          # - fail_format_diff
-          # - fail_invalid_resource_type
+          - pass_character_limit
+          - fail_data_source_error
+          - fail_format_diff
+          - fail_invalid_resource_type
 
     steps:
       - name: Echo context
@@ -50,9 +48,8 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
-          command: apply # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
-          arg-auto-approve: true
-          # arg-lock: ${{ github.event.pull_request.merged }}
+          command: ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
+          arg-lock: ${{ github.event.pull_request.merged }}
           working-directory: tests/${{ matrix.test }}
           tool: tofu
           format: true

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
           pr_number=$(echo "${GITHUB_REF_NAME}" | sed -n 's/.*pr-\([0-9]*\)-.*/\1/p')
         else
           # Get the PR number from the event payload or fallback on 0.
-          pr_number=${{ github.event.number || 0 }}
+          pr_number=${{ github.event.number || github.event.issue.number || 0 }}
         fi
         echo "pr=$pr_number" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Resolves #354 (specifically @tenpaiyomi's [comment](https://github.com/OP5dev/TF-via-PR/issues/354#issuecomment-2563928831)).

### Fixed

- Determine PR number from `issue_comment` event trigger, in addition existing support for `push`, `pull_request` and `merge_group` events (thank you, @tenpaiyomi).

### Tested

- [x] 1. Amend "[tf_tests.yaml](https://github.com/OP5dev/TF-via-PR/blob/main/.github/workflows/tf_tests.yaml)" to be triggered by `issue_comment`.
- [x] 2. Change TF-via-PR inputs to render `apply -auto-approve`.
- [x] 3. Validate github-bot's PR comment is generated following workflow execution.
- [x] 4. Revert changes to "tf_tests.yaml" before merge.