### PR TITLE
docs: add `labeled` workflow example

### DIFF
--- a/.github/examples/pr_self_hosted.yaml
+++ b/.github/examples/pr_self_hosted.yaml
@@ -1,12 +1,14 @@
 ---
-name: Trigger on pull_request (plan or apply) event with Terraform and OpenTofu on self-hosted runner.
+name: Trigger on pull_request (plan or apply) and labeled (manual) events on self-hosted Terraform and OpenTofu.
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, closed]
+    types: [opened, synchronize, closed, labeled]
 
 jobs:
   tf:
+    # Run on usual PR events and when labeled with 'tf-plan'.
+    if: ${{ contains(fromJSON('["opened", "synchronize", "closed"]'), github.event.action) || contains(github.event.pull_request.labels.*.name, 'tf-plan') }}
     runs-on: self-hosted
 
     permissions:
@@ -38,3 +40,10 @@ jobs:
           working-directory: path/to/directory
           plan-encrypt: ${{ secrets.PASSPHRASE }}
           tool: ${{ env.tool }}
+
+      - name: Remove label
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'tf-plan') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: gh api /repos/{owner}/{repo}/issues/${PR_NUMBER}/labels/tf-plan --method DELETE

--- a/.github/workflows/tf_tests.yaml
+++ b/.github/workflows/tf_tests.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     permissions:
-      actions: read # Required to download repository artifact.
+      actions: read # Required to identify workflow run.
       checks: write # Required to add status summary.
       contents: read # Required to checkout repository.
-      pull-requests: write # Required to add PR comment and label.
+      pull-requests: write # Required to add comment and label.
 
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The following workflows showcase common use cases, while a comprehensive list of
     </td>
     <td>
       </br>
-      <a href="/.github/examples/pr_self_hosted.yaml"><strong>Run on</strong></a> <code>pull_request</code> (plan or apply) event with Terraform and OpenTofu on <strong>self-hosted</strong> runner.
+      <a href="/.github/examples/pr_self_hosted.yaml"><strong>Run on</strong></a> <code>pull_request</code> (plan or apply) and <code>labeled</code> <strong>(manual) events on self-hosted</strong> Terraform and OpenTofu.
       </br></br>
     </td>
   </tr>


### PR DESCRIPTION
Tangentially follows on from #354 regarding manual workflow trigger.