### PR TITLE
docs: add @3ware sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,3 +283,5 @@ View [all notable changes](https://github.com/op5dev/tf-via-pr/releases "Release
 - Copyright 2016-2024 [Rishav Dhar](https://github.com/rdhar "Rishav Dhar's GitHub profile.") — All wrongs reserved.
 
 ### Sponsors
+
+- [@3ware](https://github.com/3ware)


### PR DESCRIPTION
Following on from #382, we should list sponsors at the end of the Readme as gratitude for their support.

Tagging @chris3ware to confirm:

1. Permission to add @3ware to the sponsors list.
1. Preference on @3ware vs. @chris3ware handle.

Thank you.