### PR TITLE
docs: add @StoatLabs sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,3 +283,5 @@ View [all notable changes](https://github.com/op5dev/tf-via-pr/releases "Release
 - Copyright 2016-2024 [Rishav Dhar](https://github.com/rdhar "Rishav Dhar's GitHub profile.") — All wrongs reserved.
 
 ### Sponsors
+
+- [@StoatLabs](https://github.com/StoatLabs)


### PR DESCRIPTION
Following on from #382, we should list sponsors at the end of the Readme as gratitude for their support.

Tagging @tenpaiyomi to confirm:

1. Permission to add @StoatLabs to the sponsors list.
1. Preference on @StoatLabs vs. @tenpaiyomi handle.

Thank you.