### PR TITLE
docs: add @ego93 sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,3 +283,5 @@ View [all notable changes](https://github.com/op5dev/tf-via-pr/releases "Release
 - Copyright 2016-2024 [Rishav Dhar](https://github.com/rdhar "Rishav Dhar's GitHub profile.") — All wrongs reserved.
 
 ### Sponsors
+
+- [@ego93](https://github.com/ego93)


### PR DESCRIPTION
Following on from #382, we should list sponsors at the end of the Readme as gratitude for their support.

Tagging @ego93 to confirm they're happy to be added to the sponsors list.

Thank you.