### PR TITLE
feat: add additional-artifacts [copilot]

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ jobs:
           arg-var-file: env/dev.tfvars
           arg-workspace: dev-use1
           plan-encrypt: ${{ secrets.PASSPHRASE }}
+          additional-artifacts: path/to/file1,path/to/dir1
 ```
 
 > [!TIP]
@@ -164,6 +165,8 @@ For each workflow run, a matrix-friendly job summary with logs is added as a fal
 | UI       | `tag-actor`         | Tag the workflow triggering actor: `always`, `on-change`, or `never`.<sup>4</sup></br>Default: `always`           |
 | UI       | `hide-args`         | Hide comma-separated list of CLI arguments from the command input.</br>Default: `detailed-exitcode,lock,out,var=` |
 | UI       | `show-args`         | Show comma-separated list of CLI arguments in the command input.</br>Default: `workspace`                         |
+| CLI      | `additional-artifacts` | Comma-separated list of paths to additional files and/or directories to be stored with upload-artifact action.</br>Example: `path/to/file1,path/to/dir1` |
+
 </br>
 
 

--- a/action.yml
+++ b/action.yml
@@ -185,6 +185,17 @@ runs:
         unzip "${{ steps.identifier.outputs.name }}.zip" -d "${{ inputs.arg-chdir || inputs.working-directory }}"
         rm --force "${{ steps.identifier.outputs.name }}.zip"
 
+        # Download additional artifacts.
+        if [[ -n "${{ inputs.additional-artifacts }}" ]]; then
+          IFS=',' read -ra artifacts <<< "${{ inputs.additional-artifacts }}"
+          for artifact in "${artifacts[@]}"; do
+            artifact_id=$(gh api /repos/{owner}/{repo}/actions/artifacts --header "$GH_API" --method GET --field "name=$(basename "$artifact")" --jq '.artifacts[0].id')
+            gh api /repos/{owner}/{repo}/actions/artifacts/${artifact_id}/zip --header "$GH_API" --method GET > "$(basename "$artifact").zip"
+            unzip "$(basename "$artifact").zip" -d "$(dirname "$artifact")"
+            rm --force "$(basename "$artifact").zip"
+          done
+        fi
+
     - if: ${{ inputs.plan-encrypt != '' && steps.download.outcome == 'success' }}
       env:
         pass: ${{ inputs.plan-encrypt }}
@@ -226,6 +237,14 @@ runs:
         name: ${{ steps.identifier.outputs.name }}
         path: ${{ format('{0}{1}tfplan', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || '') }}
         overwrite: true
+
+        # Upload additional artifacts.
+        if [[ -n "${{ inputs.additional-artifacts }}" ]]; then
+          IFS=',' read -ra artifacts <<< "${{ inputs.additional-artifacts }}"
+          for artifact in "${artifacts[@]}"; do
+            gh api /repos/{owner}/{repo}/actions/artifacts --header "$GH_API" --method POST --field "name=$(basename "$artifact")" --field "path=$artifact"
+          done
+        fi
 
     - if: ${{ inputs.plan-parity == 'true' && steps.download.outcome == 'success' }}
       shell: bash
@@ -498,6 +517,10 @@ inputs:
   working-directory:
     default: ""
     description: "Specify the working directory of TF code, alias of `arg-chdir` (e.g., `stacks/dev`)."
+    required: false
+  additional-artifacts:
+    default: ""
+    description: "Comma-separated list of paths to additional files and/or directories to be stored with upload-artifact action (e.g., `path/to/file1,path/to/dir1`)."
     required: false
 
   # CLI arguments.


### PR DESCRIPTION
Add support for additional artifacts in terraform plan and apply commands.

* Add new input `additional-artifacts` to `action.yml` to accept a comma-separated list of paths to files and/or directories.
* Modify the `plan` step in `action.yml` to include the additional artifacts in the upload-artifact action.
* Modify the `download` step in `action.yml` to download and unzip the additional artifacts to their original locations.
* Update documentation in `README.md` to reflect the new `additional-artifacts` input and its usage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OP5dev/TF-via-PR/pull/388?shareId=2cd4e17e-49e1-41cf-9590-e4639bc9ff5d).