### PR TITLE
feat: support github enterprise (ghe)

### DIFF
--- a/.github/examples/pr_self_hosted.yaml
+++ b/.github/examples/pr_self_hosted.yaml
@@ -1,5 +1,5 @@
 ---
-name: Trigger on pull_request (plan or apply) and labeled (manual) events on self-hosted Terraform and OpenTofu.
+name: Trigger on pull_request (plan or apply) and labeled (manual) events on GitHub Enterprise self-hosted runner.
 
 on:
   pull_request:
@@ -45,7 +45,9 @@ jobs:
           plan-encrypt: ${{ secrets.PASSPHRASE }}
           validate: true
           format: true
-          tool: ${{ env.tool }}
+          tool: ${{ secrets.GH_ENTERPRISE_TOKEN }}
+        env:
+          GH_ENTERPRISE_TOKEN: ${{ secrets.GH_ENTERPRISE_TOKEN }}
 
       - name: Remove label
         if: ${{ contains(github.event.pull_request.labels.*.name, 'tf-plan') }}

--- a/.github/examples/pr_self_hosted.yaml
+++ b/.github/examples/pr_self_hosted.yaml
@@ -45,7 +45,7 @@ jobs:
           plan-encrypt: ${{ secrets.PASSPHRASE }}
           validate: true
           format: true
-          tool: ${{ secrets.GH_ENTERPRISE_TOKEN }}
+          tool: ${{ env.tool }}
         env:
           GH_ENTERPRISE_TOKEN: ${{ secrets.GH_ENTERPRISE_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The following workflows showcase common use cases, while a comprehensive list of
     </td>
     <td>
       </br>
-      <a href="/.github/examples/pr_self_hosted.yaml"><strong>Run on</strong></a> <code>pull_request</code> (plan or apply) and <code>labeled</code> <strong>manual</strong> events on <strong>self-hosted</strong> Terraform/OpenTofu.
+      <a href="/.github/examples/pr_self_hosted.yaml"><strong>Run on</strong></a> <code>pull_request</code> (plan or apply) and <code>labeled</code> <strong>manual</strong> events on GitHub Enterprise<strong>self-hosted runner</strong>.
       </br></br>
     </td>
   </tr>

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
         echo TF_CLI_ARGS=$([[ -n "${{ env.TF_CLI_ARGS }}" ]] && echo "${{ env.TF_CLI_ARGS }} -no-color" || echo "-no-color") >> "$GITHUB_ENV"
         echo TF_IN_AUTOMATION="true" >> "$GITHUB_ENV"
         echo TF_INPUT="false" >> "$GITHUB_ENV"
-        echo $GITHUB_SERVER_URL
+        if [[ "$GITHUB_SERVER_URL" != "https://github.com" ]]; then echo GH_HOST=$(echo "$GITHUB_SERVER_URL" | sed 's/.*:\/\///') >> "$GITHUB_ENV"; fi
 
         # CLI arguments.
         echo arg-auto-approve=$([[ -n "${{ inputs.arg-auto-approve }}" ]] && echo " -auto-approve" || echo "") >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -220,13 +220,20 @@ runs:
         openssl enc -aes-256-ctr -pbkdf2 -salt -in "$path" -out "$path.encrypted" -pass file:"$temp_file"
         mv "$path.encrypted" "$path"
 
-    - if: ${{ inputs.command == 'plan' }}
+    - if: ${{ inputs.command == 'plan' && env.GITHUB_SERVER_URL == 'https://github.com' }}
       id: upload
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: ${{ steps.identifier.outputs.name }}
         path: ${{ format('{0}{1}tfplan', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || '') }}
         overwrite: true
+
+    - if: ${{ inputs.command == 'plan' && env.GITHUB_SERVER_URL != 'https://github.com' }}
+      id: upload-v3
+      uses: actions/upload-artifact@c24449f33cd45d4826c6702db7e49f7cdb9b551d # v3.2.1-node20
+      with:
+        name: ${{ steps.identifier.outputs.name }}
+        path: ${{ format('{0}{1}tfplan', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || '') }}
 
     - if: ${{ inputs.plan-parity == 'true' && steps.download.outcome == 'success' }}
       shell: bash
@@ -428,10 +435,10 @@ outputs:
     value: ${{ steps.identifier.outputs.job }}
   plan-id:
     description: "ID of the plan file artifact."
-    value: ${{ steps.upload.outputs.artifact-id }}
+    value: ${{ steps.upload.outputs.artifact-id || steps.upload-v3.outputs.artifact-id }}
   plan-url:
     description: "URL of the plan file artifact."
-    value: ${{ steps.upload.outputs.artifact-url }}
+    value: ${{ steps.upload.outputs.artifact-url || steps.upload-v3.outputs.artifact-url }}
   result:
     description: "Result of the last TF command (truncated)."
     value: ${{ steps.post.outputs.result }}

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,7 @@ runs:
         echo TF_CLI_ARGS=$([[ -n "${{ env.TF_CLI_ARGS }}" ]] && echo "${{ env.TF_CLI_ARGS }} -no-color" || echo "-no-color") >> "$GITHUB_ENV"
         echo TF_IN_AUTOMATION="true" >> "$GITHUB_ENV"
         echo TF_INPUT="false" >> "$GITHUB_ENV"
+        echo $GITHUB_SERVER_URL
 
         # CLI arguments.
         echo arg-auto-approve=$([[ -n "${{ inputs.arg-auto-approve }}" ]] && echo " -auto-approve" || echo "") >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Added

- [x] #401 Set `GH_HOST` environment variable when run within GitHub Enterprise (GHE) for GitHub CLI authentication using [`GITHUB_SERVER_URL`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#:~:text=example%2C%203.-,GITHUB_SERVER_URL,-The%20URL%20of) (thank you, @ArkShocer).
  - Fallback on [actions/upload-artifact@v3](https://github.com/actions/upload-artifact) for GHE compatibility.
- [x] [Example workflow](https://github.com/OP5dev/TF-via-PR/blob/main/.github/examples/pr_self_hosted.yaml) to demonstrate usage scenario using [`GH_ENTERPRISE_TOKEN`](https://cli.github.com/manual/#:~:text=export-,GH_ENTERPRISE_TOKEN,-%3D%3Caccess%2Dtoken%3E) (thank you,  @ArkShocer).

Resolves #399.