### PR TITLE
feat: expand manual trigger example

### DIFF
--- a/.github/examples/pr_manual_label.yaml
+++ b/.github/examples/pr_manual_label.yaml
@@ -17,7 +17,7 @@ on:
         required: false
         type: boolean
   pull_request:
-    types: [labeled]
+    types: [labeled] # https://docs.github.com/actions/learn-github-actions/events-that-trigger-workflows
 
 jobs:
   tf:

--- a/.github/examples/pr_manual_label.yaml
+++ b/.github/examples/pr_manual_label.yaml
@@ -1,14 +1,26 @@
 ---
-name: Trigger on pull_request (plan or apply) and labeled (manual) events on GitHub Enterprise self-hosted runner.
+name: Trigger on labeled and workflow_dispatch manual events on GitHub Enterprise (GHE) self-hosted runner.
 
 on:
+  workflow_dispatch:
+    inputs:
+      command:
+        description: TF command
+        required: true
+        type: choice
+        options:
+          - plan
+          - apply
+        default: plan
+      lock:
+        description: TF lock
+        required: false
+        type: boolean
   pull_request:
-    types: [opened, synchronize, closed, labeled]
+    types: [labeled]
 
 jobs:
   tf:
-    # Run on usual PR events and when labeled with 'tf-plan'.
-    if: ${{ contains(fromJSON('["opened", "synchronize", "closed"]'), github.event.action) || contains(github.event.pull_request.labels.*.name, 'run-plan') || contains(github.event.pull_request.labels.*.name, 'run-apply') }}
     runs-on: self-hosted
 
     permissions:
@@ -26,20 +38,24 @@ jobs:
         with:
           terraform_wrapper: false
 
-      - name: Provision TF
+      - name: Provision TF via pull_request
         uses: op5dev/tf-via-pr@v13
         with:
           working-directory: path/to/directory
-          command: ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
-          arg-lock: ${{ github.event.pull_request.merged }}
+          command: ${{ inputs.command != '' && inputs.command || contains(github.event.pull_request.labels.*.name, 'run-apply') && 'apply' || 'plan' }}
+          arg-lock: ${{ inputs.lock != '' && inputs.lock || contains(github.event.pull_request.labels.*.name, 'run-apply') }}
           plan-encrypt: ${{ secrets.PASSPHRASE }}
-          validate: true
           format: true
+          validate: true
         env:
           GH_ENTERPRISE_TOKEN: ${{ secrets.GH_ENTERPRISE_TOKEN }}
+          TF_DATA_DIR: path/to/.terraform
+          TF_LOG: ERROR
 
       - name: Remove label
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'run-plan') || contains(github.event.pull_request.labels.*.name, 'run-apply') }}
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'run-plan') ||
+          contains(github.event.pull_request.labels.*.name, 'run-apply')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}

--- a/.github/examples/pr_self_hosted.yaml
+++ b/.github/examples/pr_self_hosted.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   tf:
     # Run on usual PR events and when labeled with 'tf-plan'.
-    if: ${{ contains(fromJSON('["opened", "synchronize", "closed"]'), github.event.action) || contains(github.event.pull_request.labels.*.name, 'tf-plan') }}
+    if: ${{ contains(fromJSON('["opened", "synchronize", "closed"]'), github.event.action) || contains(github.event.pull_request.labels.*.name, 'run-plan') || contains(github.event.pull_request.labels.*.name, 'run-apply') }}
     runs-on: self-hosted
 
     permissions:
@@ -17,24 +17,14 @@ jobs:
       contents: read       # Required to checkout repository.
       pull-requests: write # Required to add comment and label.
 
-    env:
-      tool: terraform
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Setup Terraform
-        if: env.tool == 'terraform'
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-
-      - name: Setup OpenTofu
-        if: env.tool == 'tofu'
-        uses: opentofu/setup-opentofu@v1
-        with:
-          tofu_wrapper: false
 
       - name: Provision TF
         uses: op5dev/tf-via-pr@v13
@@ -45,13 +35,13 @@ jobs:
           plan-encrypt: ${{ secrets.PASSPHRASE }}
           validate: true
           format: true
-          tool: ${{ env.tool }}
         env:
           GH_ENTERPRISE_TOKEN: ${{ secrets.GH_ENTERPRISE_TOKEN }}
 
       - name: Remove label
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'tf-plan') }}
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'run-plan') || contains(github.event.pull_request.labels.*.name, 'run-apply') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
-        run: gh api /repos/{owner}/{repo}/issues/${PR_NUMBER}/labels/tf-plan --method DELETE
+          PR_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-plan') && 'run-plan' || 'run-apply' }}
+        run: gh api /repos/{owner}/{repo}/issues/${PR_NUMBER}/labels/${PR_LABEL} --method DELETE

--- a/README.md
+++ b/README.md
@@ -63,10 +63,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
       - uses: op5dev/tf-via-pr@v13
         with:
-          # Run plan by default, or apply on merge with lock.
+          # Run plan by default, or apply on push with lock.
           working-directory: path/to/directory
           command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
           arg-lock: ${{ github.event_name == 'push' }}
@@ -120,7 +124,7 @@ The following workflows showcase common use cases, while a comprehensive list of
     </td>
     <td>
       </br>
-      <a href="/.github/examples/pr_self_hosted.yaml"><strong>Run on</strong></a> <code>pull_request</code> (plan or apply) and <code>labeled</code> <strong>manual</strong> events on GitHub Enterprise<strong>self-hosted runner</strong>.
+      <a href="/.github/examples/pr_manual_label.yaml"><strong>Run on</strong></a> <code>labeled</code> and <code>workflow_dispatch</code> <strong>manual</strong> events on GitHub Enterprise (GHE) <strong>self-hosted runner</strong>.
       </br></br>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ jobs:
 
       - uses: op5dev/tf-via-pr@v13
         with:
-          # Run plan by default, or apply on push with lock.
+          # Run plan by default, or apply on push to main.
           working-directory: path/to/directory
           command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
           arg-lock: ${{ github.event_name == 'push' }}

--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
       shell: bash
       run: |
         # Unique identifier.
-        # Get PR number using different query methods for push, merge_group, and pull_request events.
+        # Get PR number using GitHub API for different event triggers.
         if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
           # List PRs associated with the commit, then get the PR number from the head ref or the latest PR.
           associated_prs=$(gh api /repos/{owner}/{repo}/commits/${GITHUB_SHA}/pulls --header "$GH_API" --method GET --field per_page=100)

--- a/action.yml
+++ b/action.yml
@@ -84,8 +84,8 @@ runs:
           # Get the PR number by parsing the ref name.
           pr_number=$(echo "${GITHUB_REF_NAME}" | sed -n 's/.*pr-\([0-9]*\)-.*/\1/p')
         else
-          # Get the PR number from the event payload or fallback on 0.
-          pr_number=${{ github.event.number || github.event.issue.number || 0 }}
+          # Get the PR number from branch name, otherwise fallback on 0 if the PR number is not found.
+          pr_number=$(gh api /repos/{owner}/{repo}/pulls --header "$GH_API" --method GET --field per_page=100 --field head="${branch}" | jq .[0].number) || ${{ github.event.number || github.event.issue.number || 0 }}
         fi
         echo "pr=$pr_number" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Resolves #402

### Added

- Support `workflow_dispatch` trigger from PR context (thank you, [OP5dev/Current-PR](https://github.com/OP5dev/Current-PR)).
- Workflow example with PR `labeled` and `workflow_dispatch` manual event triggers (thank you, @ruzickap).