### PR TITLE
change: add basic pr label

### DIFF
--- a/.github/examples/pr_merge_matrix.yaml
+++ b/.github/examples/pr_merge_matrix.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           working-directory: path/to/${{ matrix.deployment }}
           command: ${{ github.event_name == 'merge_group' && 'apply' || 'plan' }}
-          arg-refresh: ${{ github.event_name == 'merge_group' && 'false' }} # Skip refresh on apply.
+          arg-refresh: ${{ github.event_name == 'merge_group' && 'false' || 'true' }} # Skip refresh on apply.
           arg-lock: ${{ github.event_name == 'merge_group' }}
           arg-var-file: env/${{ matrix.deployment }}.tfvars
           arg-workspace: ${{ matrix.deployment }}

--- a/action.yml
+++ b/action.yml
@@ -158,9 +158,6 @@ runs:
       shell: bash
       run: |
         # Label PR.
-        # If the label does not exist, create it before adding it to the PR in the format 'tf:${{ inputs.command }}'.
-        gh api /repos/${{ github.repository }}/labels/tf:${{ inputs.command }} --header "$GH_API" --method GET || \
-          gh api /repos/${{ github.repository }}/labels --header "$GH_API" --method POST --field "name=tf:${{ inputs.command }}" --field "description=Pull requests that ${{ inputs.command }} TF code." --field "color=5C4EE5"
         gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/labels --header "$GH_API" --method POST --field "labels[]=tf:${{ inputs.command }}"
 
     - if: ${{ inputs.command == 'plan' }}


### PR DESCRIPTION
Following on from #432, TF-via-PR currently makes a best-effort at checking if a PR label exists before creating it with a description and colour (5C4EE5).

However, on the very first run, this results in a suppressed error as it can't retrieve a PR label which doesn't exist yet, which can be confusing to new-users.

To "fix", TF-via-PR could simply not add a description or color, and just attach the "default" PR label with appropriate name (e.g., "tf:plan" or "tf:apply".

### Changed

- #434 PR labels are no longer coloured #5C4EE5 to streamline label generation and attachment.