### PR TITLE
feat: optional plan file upload

### DIFF
--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -63,12 +63,12 @@ jobs:
           arg-workspace: dev
           arg-lock: ${{ github.event.pull_request.merged }}
           arg-refresh: ${{ github.event.pull_request.merged && 'false' }}
-          command: apply # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
+          command: plan # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
           comment-pr: ${{ matrix.tool == 'tofu' && 'always' || 'never' }}
           format: true
           validate: true
           preserve-plan: true
-          plan-encrypt: secret
+          # plan-encrypt: secret
           retention-days: 1
           tag-actor: never
           tool: ${{ matrix.tool }}

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -21,13 +21,13 @@ jobs:
       matrix:
         tool:
           - tofu
-          # - terraform
+          - terraform
         test:
           - pass_one
-          # - pass_character_limit
-          # - fail_data_source_error
-          # - fail_format_diff
-          # - fail_invalid_resource_type
+          - pass_character_limit
+          - fail_data_source_error
+          - fail_format_diff
+          - fail_invalid_resource_type
 
     steps:
       - name: Echo context
@@ -88,4 +88,4 @@ jobs:
           echo "result: ${{ steps.tf.outputs.result }}"
           echo "run-url: ${{ steps.tf.outputs.run-url }}"
           echo "summary: ${{ steps.tf.outputs.summary }}"
-          tofu -chdir=tests/${{ matrix.test }} show -no-color tfplan
+          ${{ matrix.tool }} -chdir=tests/${{ matrix.test }} show -no-color tfplan

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -63,12 +63,12 @@ jobs:
           arg-workspace: dev
           arg-lock: ${{ github.event.pull_request.merged }}
           arg-refresh: ${{ github.event.pull_request.merged && 'false' }}
-          command: apply # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
+          command: ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
           comment-pr: ${{ matrix.tool == 'tofu' && 'always' || 'never' }}
           format: true
           validate: true
           preserve-plan: true
-          # plan-encrypt: secret
+          plan-encrypt: ${{ secrets.TF_ENCRYPTION }}
           retention-days: 1
           tag-actor: never
           tool: ${{ matrix.tool }}
@@ -88,7 +88,4 @@ jobs:
           echo "result: ${{ steps.tf.outputs.result }}"
           echo "run-url: ${{ steps.tf.outputs.run-url }}"
           echo "summary: ${{ steps.tf.outputs.summary }}"
-
-      - run: ls -la tests/${{ matrix.test }}
-
-      # - run: tofu -chdir=tests/${{ matrix.test }} show -no-color tfplan
+          tofu -chdir=tests/${{ matrix.test }} show -no-color tfplan

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -63,7 +63,7 @@ jobs:
           arg-workspace: dev
           arg-lock: ${{ github.event.pull_request.merged }}
           arg-refresh: ${{ github.event.pull_request.merged && 'false' }}
-          command: plan # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
+          command: apply # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
           comment-pr: ${{ matrix.tool == 'tofu' && 'always' || 'never' }}
           format: true
           validate: true
@@ -90,7 +90,7 @@ jobs:
           echo "summary: ${{ steps.tf.outputs.summary }}"
 
       - name: Echo TFplan
-        if: 'true' # on plan
+        if: 'false' # on plan
         run: |
           ls -la tests/${{ matrix.test }}
           tofu -chdir=tests/${{ matrix.test }} show -no-color tfplan

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -90,7 +90,7 @@ jobs:
           echo "summary: ${{ steps.tf.outputs.summary }}"
 
       - name: Echo TFplan
-        if: inputs.command == 'plan'
+        if: 'true' # on plan
         run: |
           ls -la tests/${{ matrix.test }}
           tofu -chdir=tests/${{ matrix.test }} show -no-color tfplan

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -90,4 +90,5 @@ jobs:
           echo "summary: ${{ steps.tf.outputs.summary }}"
 
       - run: ls -la tests/${{ matrix.test }}
+
       # - run: tofu -chdir=tests/${{ matrix.test }} show -no-color tfplan

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -63,7 +63,7 @@ jobs:
           arg-workspace: dev
           arg-lock: ${{ github.event.pull_request.merged }}
           arg-refresh: ${{ github.event.pull_request.merged && 'false' }}
-          command: apply # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
+          command: plan # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
           comment-pr: ${{ matrix.tool == 'tofu' && 'always' || 'never' }}
           format: true
           validate: true

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -67,8 +67,8 @@ jobs:
           comment-pr: ${{ matrix.tool == 'tofu' && 'always' || 'never' }}
           format: true
           validate: true
-          preserve-plan: true
-          # plan-encrypt: secret
+          # preserve-plan: true
+          plan-encrypt: secret
           retention-days: 1
           tag-actor: never
           tool: ${{ matrix.tool }}

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -90,6 +90,7 @@ jobs:
           echo "summary: ${{ steps.tf.outputs.summary }}"
 
       - name: Echo TFplan
+        if: inputs.command == 'plan'
         run: |
           ls -la tests/${{ matrix.test }}
           tofu -chdir=tests/${{ matrix.test }} show -no-color tfplan

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -63,7 +63,7 @@ jobs:
           arg-workspace: dev
           arg-lock: ${{ github.event.pull_request.merged }}
           arg-refresh: ${{ github.event.pull_request.merged && 'false' }}
-          command: apply # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
+          command: plan # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
           comment-pr: ${{ matrix.tool == 'tofu' && 'always' || 'never' }}
           format: true
           validate: true
@@ -89,8 +89,5 @@ jobs:
           echo "run-url: ${{ steps.tf.outputs.run-url }}"
           echo "summary: ${{ steps.tf.outputs.summary }}"
 
-      - name: Echo TFplan
-        if: 'false' # on plan
-        run: |
-          ls -la tests/${{ matrix.test }}
-          tofu -chdir=tests/${{ matrix.test }} show -no-color tfplan
+      - run: ls -la tests/${{ matrix.test }}
+      - run: tofu -chdir=tests/${{ matrix.test }} show -no-color tfplan

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -74,6 +74,7 @@ jobs:
           tool: ${{ matrix.tool }}
 
       - name: Echo TF
+        continue-on-error: true
         run: |
           echo "check-id: ${{ steps.tf.outputs.check-id }}"
           echo "command: ${{ steps.tf.outputs.command }}"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -1,5 +1,5 @@
 ---
-name: Tests
+name: Test CI
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
     types: [opened, reopened, synchronize, closed]
 
 jobs:
-  tests:
+  ci:
     runs-on: ubuntu-24.04
 
     permissions:

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -63,11 +63,11 @@ jobs:
           arg-workspace: dev
           arg-lock: ${{ github.event.pull_request.merged }}
           arg-refresh: ${{ github.event.pull_request.merged && 'false' }}
-          command: plan # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
+          command: apply # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
           comment-pr: ${{ matrix.tool == 'tofu' && 'always' || 'never' }}
           format: true
           validate: true
-          # preserve-plan: true
+          preserve-plan: true
           plan-encrypt: secret
           retention-days: 1
           tag-actor: never
@@ -90,4 +90,4 @@ jobs:
           echo "summary: ${{ steps.tf.outputs.summary }}"
 
       - run: ls -la tests/${{ matrix.test }}
-      - run: tofu -chdir=tests/${{ matrix.test }} show -no-color tfplan
+      # - run: tofu -chdir=tests/${{ matrix.test }} show -no-color tfplan

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -63,7 +63,7 @@ jobs:
           arg-workspace: dev
           arg-lock: ${{ github.event.pull_request.merged }}
           arg-refresh: ${{ github.event.pull_request.merged && 'false' }}
-          command: plan # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
+          command: apply # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
           comment-pr: ${{ matrix.tool == 'tofu' && 'always' || 'never' }}
           format: true
           validate: true

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -68,7 +68,7 @@ jobs:
           format: true
           validate: true
           preserve-plan: true
-          plan-encrypt: secret
+          # plan-encrypt: secret
           retention-days: 1
           tag-actor: never
           tool: ${{ matrix.tool }}

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -68,7 +68,7 @@ jobs:
           format: true
           validate: true
           preserve-plan: true
-          # plan-encrypt: secret
+          plan-encrypt: secret
           tag-actor: never
           tool: ${{ matrix.tool }}
 

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -21,13 +21,13 @@ jobs:
       matrix:
         tool:
           - tofu
-          - terraform
+          # - terraform
         test:
           - pass_one
-          - pass_character_limit
-          - fail_data_source_error
-          - fail_format_diff
-          - fail_invalid_resource_type
+          # - pass_character_limit
+          # - fail_data_source_error
+          # - fail_format_diff
+          # - fail_invalid_resource_type
 
     steps:
       - name: Echo context
@@ -85,3 +85,7 @@ jobs:
           echo "result: ${{ steps.tf.outputs.result }}"
           echo "run-url: ${{ steps.tf.outputs.run-url }}"
           echo "summary: ${{ steps.tf.outputs.summary }}"
+
+      - name: Echo TFplan
+        run: |
+          tofu show -no-color tests/${{ matrix.test }}/${{ steps.tf.outputs.identifier }}

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -91,4 +91,4 @@ jobs:
       - name: Echo TFplan
         run: |
           ls -la tests/${{ matrix.test }}
-          tofu -chdir tests/${{ matrix.test }} show -no-color tfplan
+          tofu -chdir=tests/${{ matrix.test }} show -no-color tfplan

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -91,4 +91,4 @@ jobs:
       - name: Echo TFplan
         run: |
           ls -la tests/${{ matrix.test }}
-          tofu show -no-color tests/${{ matrix.test }}/tfplan
+          tofu -chdir tests/${{ matrix.test }} show -no-color tfplan

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -67,6 +67,7 @@ jobs:
           comment-pr: ${{ matrix.tool == 'tofu' && 'always' || 'never' }}
           format: true
           validate: true
+          preserve-plan: true
           tag-actor: never
           tool: ${{ matrix.tool }}
 
@@ -88,4 +89,5 @@ jobs:
 
       - name: Echo TFplan
         run: |
+          la -la tests/${{ matrix.test }}
           tofu show -no-color tests/${{ matrix.test }}/${{ steps.tf.outputs.identifier }}

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -63,7 +63,7 @@ jobs:
           arg-workspace: dev
           arg-lock: ${{ github.event.pull_request.merged }}
           arg-refresh: ${{ github.event.pull_request.merged && 'false' }}
-          command: ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
+          command: apply # ${{ github.event.pull_request.merged && 'apply' || 'plan' }}
           comment-pr: ${{ matrix.tool == 'tofu' && 'always' || 'never' }}
           format: true
           validate: true

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -89,5 +89,5 @@ jobs:
 
       - name: Echo TFplan
         run: |
-          la -la tests/${{ matrix.test }}
+          ls -la tests/${{ matrix.test }}
           tofu show -no-color tests/${{ matrix.test }}/${{ steps.tf.outputs.identifier }}

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -68,6 +68,7 @@ jobs:
           format: true
           validate: true
           preserve-plan: true
+          # plan-encrypt: secret
           tag-actor: never
           tool: ${{ matrix.tool }}
 
@@ -90,4 +91,4 @@ jobs:
       - name: Echo TFplan
         run: |
           ls -la tests/${{ matrix.test }}
-          tofu show -no-color tests/${{ matrix.test }}/${{ steps.tf.outputs.identifier }}
+          tofu show -no-color tests/${{ matrix.test }}/tfplan

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -69,6 +69,7 @@ jobs:
           validate: true
           preserve-plan: true
           plan-encrypt: secret
+          retention-days: 1
           tag-actor: never
           tool: ${{ matrix.tool }}
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
 | Check    | `validate`          | Check validation of TF code.</br>Default: `false`                                                                                         |
 | Check    | `plan-parity`       | Replace plan file if it matches a newly-generated one to prevent stale apply.<sup>2</sup></br>Default: `false`                            |
 | Security | `plan-encrypt`      | Encrypt plan file artifact with the given input.<sup>3</sup></br>Example: `${{ secrets.PASSPHRASE }}`                                     |
-| Security | `preserve-plan`     | Preserve plan file in the given working directory after workflow execution.</br>Default: `false`                                          |
+| Security | `preserve-plan`     | Preserve plan file "tfplan" in the given working directory after workflow execution.</br>Default: `false`                                 |
 | Security | `upload-plan`       | Upload plan file as GitHub workflow artifact.</br>Default: `true`                                                                         |
 | Security | `retention-days`    | Duration after which plan file artifact will expire in days.</br>Example: `90`                                                            |
 | Security | `token`             | Specify a GitHub token.</br>Default: `${{ github.token }}`                                                                                |

--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
 1. Both `command: plan` and `command: apply` include: `init`, `fmt` (with `format: true`), `validate` (with `validate: true`), and `workspace` (with `arg-workspace`) commands rolled into it automatically.</br>
   To separately run checks and/or generate outputs only, `command: init` can be used.</br></br>
 1. Originally intended for `merge_group` event trigger, `plan-parity: true` input helps to prevent stale apply within a series of workflow runs when merging multiple PRs.</br></br>
-2. The secret string input for `plan-encrypt` can be of any length, as long as it's consistent between encryption (plan) and decryption (apply).</br></br>
-3. The `on-change` option is true when the exit code of the last TF command is non-zero (ensure `terraform_wrapper`/`tofu_wrapper` is set to `false`).</br></br>
-4. The default behavior of `comment-method` is to update the existing PR comment with the latest plan/apply output, making it easy to track changes over time through the comment's revision history.</br></br>
+1. The secret string input for `plan-encrypt` can be of any length, as long as it's consistent between encryption (plan) and decryption (apply).</br></br>
+1. The `on-change` option is true when the exit code of the last TF command is non-zero (ensure `terraform_wrapper`/`tofu_wrapper` is set to `false`).</br></br>
+1. The default behavior of `comment-method` is to update the existing PR comment with the latest plan/apply output, making it easy to track changes over time through the comment's revision history.</br></br>
   [![PR comment revision history comparing plan and apply outputs.](/.github/assets/revisions.png)](https://raw.githubusercontent.com/op5dev/tf-via-pr/refs/heads/main/.github/assets/revisions.png "View full-size image.")</br></br>
 1. It can be desirable to hide certain arguments from the last run command input to prevent exposure in the PR comment (e.g., sensitive `arg-var` values). Conversely, it can be desirable to show other arguments even if they are not in last run command input (e.g., `arg-workspace` or `arg-backend-config` selection).
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
 | Check    | `validate`          | Check validation of TF code.</br>Default: `false`                                                                                         |
 | Check    | `plan-parity`       | Replace plan file if it matches a newly-generated one to prevent stale apply.<sup>2</sup></br>Default: `false`                            |
 | Security | `plan-encrypt`      | Encrypt plan file artifact with the given input.<sup>3</sup></br>Example: `${{ secrets.PASSPHRASE }}`                                     |
+| Security | `preserve-plan`     | Preserve plan file in the given working directory after workflow execution.</br>Default: `false`                                          |
+| Security | `upload-plan`       | Upload plan file as GitHub workflow artifact.</br>Default: `true`                                                                         |
 | Security | `retention-days`    | Duration after which plan file artifact will expire in days.</br>Example: `90`                                                            |
 | Security | `token`             | Specify a GitHub token.</br>Default: `${{ github.token }}`                                                                                |
 | UI       | `label-pr`          | Add a PR label with the command input (e.g., `tf:plan`).</br>Default: `true`                                                              |
@@ -179,9 +181,9 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
 1. Both `command: plan` and `command: apply` include: `init`, `fmt` (with `format: true`), `validate` (with `validate: true`), and `workspace` (with `arg-workspace`) commands rolled into it automatically.</br>
   To separately run checks and/or generate outputs only, `command: init` can be used.</br></br>
 1. Originally intended for `merge_group` event trigger, `plan-parity: true` input helps to prevent stale apply within a series of workflow runs when merging multiple PRs.</br></br>
-1. The secret string input for `plan-encrypt` can be of any length, as long as it's consistent between encryption (plan) and decryption (apply).</br></br>
-1. The `on-change` option is true when the exit code of the last TF command is non-zero (ensure `terraform_wrapper`/`tofu_wrapper` is set to `false`).</br></br>
-1. The default behavior of `comment-method` is to update the existing PR comment with the latest plan/apply output, making it easy to track changes over time through the comment's revision history.</br></br>
+2. The secret string input for `plan-encrypt` can be of any length, as long as it's consistent between encryption (plan) and decryption (apply).</br></br>
+3. The `on-change` option is true when the exit code of the last TF command is non-zero (ensure `terraform_wrapper`/`tofu_wrapper` is set to `false`).</br></br>
+4. The default behavior of `comment-method` is to update the existing PR comment with the latest plan/apply output, making it easy to track changes over time through the comment's revision history.</br></br>
   [![PR comment revision history comparing plan and apply outputs.](/.github/assets/revisions.png)](https://raw.githubusercontent.com/op5dev/tf-via-pr/refs/heads/main/.github/assets/revisions.png "View full-size image.")</br></br>
 1. It can be desirable to hide certain arguments from the last run command input to prevent exposure in the PR comment (e.g., sensitive `arg-var` values). Conversely, it can be desirable to show other arguments even if they are not in last run command input (e.g., `arg-workspace` or `arg-backend-config` selection).
 

--- a/action.yml
+++ b/action.yml
@@ -165,9 +165,6 @@ runs:
     - if: ${{ inputs.command == 'apply' && inputs.arg-auto-approve != 'true' }}
       id: download
       shell: bash
-      env:
-        PLAN_ENCRYPT: ${{ inputs.plan-encrypt }}
-        path: ${{ format('{0}{1}tfplan', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || '') }}
       run: |
         # Download plan file.
         # Get the artifact ID of the latest matching plan files for download.
@@ -179,11 +176,6 @@ runs:
         unzip "${{ steps.identifier.outputs.name }}.zip" -d "${{ inputs.arg-chdir || inputs.working-directory }}"
         rm --force "${{ steps.identifier.outputs.name }}.zip"
 
-        # Rename the plan file if encrypted.
-        if [[ "$PLAN_ENCRYPT" != "" ]]; then
-          mv "$path.encrypted" "$path"
-        fi
-
     - if: ${{ inputs.plan-encrypt != '' && steps.download.outcome == 'success' }}
       env:
         pass: ${{ inputs.plan-encrypt }}
@@ -193,7 +185,7 @@ runs:
         # Decrypt plan file.
         temp_file=$(mktemp)
         printf "%s" "$pass" > "$temp_file"
-        openssl enc -aes-256-ctr -pbkdf2 -salt -in "$path" -out "$path.decrypted" -pass file:"$temp_file" -d
+        openssl enc -aes-256-ctr -pbkdf2 -salt -in "$path.encrypted" -out "$path.decrypted" -pass file:"$temp_file" -d
         mv "$path.decrypted" "$path"
 
     - if: ${{ steps.plan.outcome == 'success' || steps.download.outcome == 'success' }}

--- a/action.yml
+++ b/action.yml
@@ -205,6 +205,7 @@ runs:
 
     - if: ${{ inputs.plan-encrypt != '' && steps.plan.outcome == 'success' }}
       env:
+        PRESERVE_PLAN: ${{ inputs.preserve-plan }}
         pass: ${{ inputs.plan-encrypt }}
         path: ${{ format('{0}{1}tfplan', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || '') }}
       shell: bash
@@ -214,12 +215,17 @@ runs:
         printf "%s" "$pass" > "$temp_file"
         openssl enc -aes-256-ctr -pbkdf2 -salt -in "$path" -out "$path.encrypted" -pass file:"$temp_file"
 
+        # Optionally delete the plan file.
+        if [[ "$PRESERVE_PLAN" != "true" ]]; then
+          rm --force "$path"
+        fi
+
     - if: ${{ inputs.command == 'plan' && inputs.upload-plan == 'true' && github.server_url == 'https://github.com' }}
       id: upload
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       with:
         name: ${{ steps.identifier.outputs.name }}
-        path: ${{ format('{0}{1}tfplan{2}', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || ''), inputs.plan-encrypt != '' && '.encrypted' || '' }}
+        path: ${{ format('{0}{1}tfplan{2}', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || '', inputs.plan-encrypt != '' && '.encrypted' || '') }}
         retention-days: ${{ inputs.retention-days }}
         overwrite: true
 

--- a/action.yml
+++ b/action.yml
@@ -213,14 +213,13 @@ runs:
         temp_file=$(mktemp)
         printf "%s" "$pass" > "$temp_file"
         openssl enc -aes-256-ctr -pbkdf2 -salt -in "$path" -out "$path.encrypted" -pass file:"$temp_file"
-        mv "$path.encrypted" "$path"
 
     - if: ${{ inputs.command == 'plan' && inputs.upload-plan == 'true' && github.server_url == 'https://github.com' }}
       id: upload
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       with:
         name: ${{ steps.identifier.outputs.name }}
-        path: ${{ format('{0}{1}tfplan', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || '') }}
+        path: ${{ format('{0}{1}tfplan{2}', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || ''), inputs.plan-encrypt != '' && '.encrypted' || '' }}
         retention-days: ${{ inputs.retention-days }}
         overwrite: true
 

--- a/action.yml
+++ b/action.yml
@@ -215,7 +215,7 @@ runs:
         openssl enc -aes-256-ctr -pbkdf2 -salt -in "$path" -out "$path.encrypted" -pass file:"$temp_file"
         mv "$path.encrypted" "$path"
 
-    - if: ${{ inputs.command == 'plan' && github.server_url == 'https://github.com' }}
+    - if: ${{ inputs.command == 'plan' && inputs.upload-plan == 'true' && github.server_url == 'https://github.com' }}
       id: upload
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       with:
@@ -224,7 +224,7 @@ runs:
         retention-days: ${{ inputs.retention-days }}
         overwrite: true
 
-    - if: ${{ inputs.command == 'plan' && github.server_url != 'https://github.com' }}
+    - if: ${{ inputs.command == 'plan' && inputs.upload-plan == 'true' && github.server_url != 'https://github.com' }}
       id: upload-v3
       uses: actions/upload-artifact@c24449f33cd45d4826c6702db7e49f7cdb9b551d # v3.2.1-node20
       with:
@@ -270,6 +270,7 @@ runs:
       if: ${{ !cancelled() && steps.identifier.outcome == 'success' && contains(fromJSON('["plan", "apply", "init"]'), inputs.command) }}
       env:
         exitcode: ${{ steps.apply.outputs.exit_code || steps.plan.outputs.exit_code || steps.validate.outputs.exit_code || steps.workspace.outputs.exit_code || steps.initialize.outputs.exit_code || steps.format.outputs.exit_code }}
+        PRESERVE_PLAN: ${{ inputs.preserve-plan }}
       shell: bash
       run: |
         # Post output.
@@ -409,8 +410,13 @@ runs:
           fi
         fi
 
+        # Optionally delete the plan file.
+        if [[ "$PRESERVE_PLAN" != "true" ]]; then
+          rm --force "${{ format('{0}{1}tfplan', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || '') }}"
+        fi
+
         # Clean up files.
-        rm --force tf.command.txt tf.console.txt tf.diff.txt "${{ format('{0}{1}tfplan', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || '') }}"
+        rm --force tf.command.txt tf.console.txt tf.diff.txt
 
 outputs:
   check-id:
@@ -487,6 +493,10 @@ inputs:
     default: "false"
     description: "Replace the plan file if it matches a newly-generated one to prevent stale apply (e.g., `false`)."
     required: false
+  preserve-plan:
+    default: "false"
+    description: "Preserve plan file in the given working directory after workflow execution (e.g., `false`)."
+    required: false
   retention-days:
     default: ""
     description: "Duration after which plan file artifact will expire in days (e.g., '90')."
@@ -506,6 +516,10 @@ inputs:
   tool:
     default: "terraform"
     description: "Provisioning tool to use between: `terraform` or `tofu` (e.g., `terraform`)."
+    required: false
+  upload-plan:
+    default: "true"
+    description: "Upload plan file as GitHub workflow artifact (e.g., `true`)."
     required: false
   validate:
     default: "false"

--- a/action.yml
+++ b/action.yml
@@ -165,6 +165,9 @@ runs:
     - if: ${{ inputs.command == 'apply' && inputs.arg-auto-approve != 'true' }}
       id: download
       shell: bash
+      env:
+        PLAN_ENCRYPT: ${{ inputs.plan-encrypt }}
+        path: ${{ format('{0}{1}tfplan', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || '') }}
       run: |
         # Download plan file.
         # Get the artifact ID of the latest matching plan files for download.
@@ -175,6 +178,11 @@ runs:
         # Unzip the plan file to the working directory, then clean up the zip file.
         unzip "${{ steps.identifier.outputs.name }}.zip" -d "${{ inputs.arg-chdir || inputs.working-directory }}"
         rm --force "${{ steps.identifier.outputs.name }}.zip"
+
+        # Rename the plan file if encrypted.
+        if [[ "$PLAN_ENCRYPT" != "" ]]; then
+          mv "$path.encrypted" "$path"
+        fi
 
     - if: ${{ inputs.plan-encrypt != '' && steps.download.outcome == 'success' }}
       env:


### PR DESCRIPTION
Resolves #437

### Added

- #442 New `preserve-plan` input to preserve the plan file in the given working directory after workflow execution (default: `false).
- #442 New `upload-plan` input to upload plan file as GitHub workflow artifact (default: `true`).
