### PR TITLE
feat: optional auto-open disclosure triangle for PR comment detail views

### DIFF
--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -73,6 +73,9 @@ jobs:
           preserve-plan: true
           retention-days: 1
 
+          expand-diff: true
+          expand-summary: true
+
           comment-pr: ${{ matrix.tool == 'tofu' && 'always' || 'never' }}
           tag-actor: never
           tool: ${{ matrix.tool }}

--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
 | Security | `upload-plan`       | Upload plan file as GitHub workflow artifact.</br>Default: `true`                                                                         |
 | Security | `retention-days`    | Duration after which plan file artifact will expire in days.</br>Example: `90`                                                            |
 | Security | `token`             | Specify a GitHub token.</br>Default: `${{ github.token }}`                                                                                |
-| UI       | `expand-diff`       | Expand the collapsible diff section.</br>Default: `false`                                                                          |
-| UI       | `expand-summary`    | Expand the collapsible summary section.</br>Default: `false`                                                                       |
+| UI       | `expand-diff`       | Expand the collapsible diff section.</br>Default: `false`                                                                                 |
+| UI       | `expand-summary`    | Expand the collapsible summary section.</br>Default: `false`                                                                              |
 | UI       | `label-pr`          | Add a PR label with the command input (e.g., `tf:plan`).</br>Default: `true`                                                              |
 | UI       | `comment-pr`        | Add a PR comment: `always`, `on-change`, or `never`.<sup>4</sup></br>Default: `always`                                                    |
 | UI       | `comment-method`    | PR comment by: `update` existing comment or `recreate` and delete previous one.<sup>5</sup></br>Default: `update`                         |

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
 | Security | `upload-plan`       | Upload plan file as GitHub workflow artifact.</br>Default: `true`                                                                         |
 | Security | `retention-days`    | Duration after which plan file artifact will expire in days.</br>Example: `90`                                                            |
 | Security | `token`             | Specify a GitHub token.</br>Default: `${{ github.token }}`                                                                                |
+| UI       | `expand-diff`       | Expand the collapsible diff output section.</br>Default: `false`                                                                          |
+| UI       | `expand-summary`    | Expand the collapsible summary output section.</br>Default: `false`                                                                       |
 | UI       | `label-pr`          | Add a PR label with the command input (e.g., `tf:plan`).</br>Default: `true`                                                              |
 | UI       | `comment-pr`        | Add a PR comment: `always`, `on-change`, or `never`.<sup>4</sup></br>Default: `always`                                                    |
 | UI       | `comment-method`    | PR comment by: `update` existing comment or `recreate` and delete previous one.<sup>5</sup></br>Default: `update`                         |
@@ -180,7 +182,7 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
 </br>
 
 1. Both `command: plan` and `command: apply` include: `init`, `fmt` (with `format: true`), `validate` (with `validate: true`), and `workspace` (with `arg-workspace`) commands rolled into it automatically.</br>
-  To separately run checks and/or generate outputs only, `command: init` can be used.</br></br>
+    To separately run checks and/or generate outputs only, `command: init` can be used.</br></br>
 1. Originally intended for `merge_group` event trigger, `plan-parity: true` input helps to prevent stale apply within a series of workflow runs when merging multiple PRs.</br></br>
 1. The secret string input for `plan-encrypt` can be of any length, as long as it's consistent between encryption (plan) and decryption (apply).</br></br>
 1. The `on-change` option is true when the exit code of the last TF command is non-zero (ensure `terraform_wrapper`/`tofu_wrapper` is set to `false`).</br></br>

--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
 | Security | `upload-plan`       | Upload plan file as GitHub workflow artifact.</br>Default: `true`                                                                         |
 | Security | `retention-days`    | Duration after which plan file artifact will expire in days.</br>Example: `90`                                                            |
 | Security | `token`             | Specify a GitHub token.</br>Default: `${{ github.token }}`                                                                                |
-| UI       | `expand-diff`       | Expand the collapsible diff output section.</br>Default: `false`                                                                          |
-| UI       | `expand-summary`    | Expand the collapsible summary output section.</br>Default: `false`                                                                       |
+| UI       | `expand-diff`       | Expand the collapsible diff section.</br>Default: `false`                                                                          |
+| UI       | `expand-summary`    | Expand the collapsible summary section.</br>Default: `false`                                                                       |
 | UI       | `label-pr`          | Add a PR label with the command input (e.g., `tf:plan`).</br>Default: `true`                                                              |
 | UI       | `comment-pr`        | Add a PR comment: `always`, `on-change`, or `never`.<sup>4</sup></br>Default: `always`                                                    |
 | UI       | `comment-method`    | PR comment by: `update` existing comment or `recreate` and delete previous one.<sup>5</sup></br>Default: `update`                         |

--- a/action.yml
+++ b/action.yml
@@ -344,7 +344,7 @@ runs:
           echo "diff<<EODIFFTFVIAPR"$'\n'"$diff_truncated"$'\n'EODIFFTFVIAPR >> "$GITHUB_OUTPUT"
 
           diff="
-        <details><summary>Diff of ${diff_count} ${diff_change}.</summary>
+        <details${{ inputs.comment-pr-open-diff-view == "true" && " open" || "" }}><summary>Diff of ${diff_count} ${diff_change}.</summary>
 
         \`\`\`diff
         ${diff_truncated}
@@ -374,7 +374,7 @@ runs:
         <!-- placeholder-2 -->
         ${diff}
         <!-- placeholder-3 -->
-        <details><summary>${summary}</br>
+        <details${{ inputs.comment-pr-open-log-view == "true" && " open" || "" }}><summary>${summary}</br>
 
         <!-- placeholder-4 -->
         ###### By ${handle}${{ github.triggering_actor }} at ${{ github.event.pull_request.updated_at || github.event.comment.created_at || github.event.head_commit.timestamp || github.event.merge_group.head_commit.timestamp }} [(view log)](${run_url}).
@@ -488,6 +488,14 @@ inputs:
   comment-pr:
     default: "always"
     description: "Add a PR comment: `always`, `on-change`, or `never` (e.g., `always`)."
+    required: false
+  comment-pr-open-diff-view:
+    default: "false"
+    description: "Whether the PR comment should auto-open the short resource diff view's disclosure triangle (e.g., `false`)."
+    required: false
+  comment-pr-open-log-view:
+    default: "false"
+    description: "Whether the PR comment should auto-open the detailed log view's disclosure triangle (e.g., `false`)."
     required: false
   format:
     default: "false"

--- a/action.yml
+++ b/action.yml
@@ -344,7 +344,7 @@ runs:
           echo "diff<<EODIFFTFVIAPR"$'\n'"$diff_truncated"$'\n'EODIFFTFVIAPR >> "$GITHUB_OUTPUT"
 
           diff="
-        <details${{ inputs.comment-pr-open-diff-view == "true" && " open" || "" }}><summary>Diff of ${diff_count} ${diff_change}.</summary>
+        <details${{ inputs.comment-pr-open-diff-view == 'true' && ' open' || '' }}><summary>Diff of ${diff_count} ${diff_change}.</summary>
 
         \`\`\`diff
         ${diff_truncated}
@@ -374,7 +374,7 @@ runs:
         <!-- placeholder-2 -->
         ${diff}
         <!-- placeholder-3 -->
-        <details${{ inputs.comment-pr-open-log-view == "true" && " open" || "" }}><summary>${summary}</br>
+        <details${{ inputs.comment-pr-open-log-view == 'true' && ' open' || '' }}><summary>${summary}</br>
 
         <!-- placeholder-4 -->
         ###### By ${handle}${{ github.triggering_actor }} at ${{ github.event.pull_request.updated_at || github.event.comment.created_at || github.event.head_commit.timestamp || github.event.merge_group.head_commit.timestamp }} [(view log)](${run_url}).

--- a/action.yml
+++ b/action.yml
@@ -491,11 +491,11 @@ inputs:
     required: false
   expand-diff:
     default: "false"
-    description: "Expand the collapsible diff output section (e.g., `false`)."
+    description: "Expand the collapsible diff section (e.g., `false`)."
     required: false
   expand-summary:
     default: "false"
-    description: "Expand the collapsible summary output section (e.g., `false`)."
+    description: "Expand the collapsible summary section (e.g., `false`)."
     required: false
   format:
     default: "false"

--- a/action.yml
+++ b/action.yml
@@ -344,7 +344,7 @@ runs:
           echo "diff<<EODIFFTFVIAPR"$'\n'"$diff_truncated"$'\n'EODIFFTFVIAPR >> "$GITHUB_OUTPUT"
 
           diff="
-        <details${{ inputs.comment-pr-open-diff-view == 'true' && ' open' || '' }}><summary>Diff of ${diff_count} ${diff_change}.</summary>
+        <details${{ inputs.expand-diff == 'true' && ' open' || '' }}><summary>Diff of ${diff_count} ${diff_change}.</summary>
 
         \`\`\`diff
         ${diff_truncated}
@@ -374,7 +374,7 @@ runs:
         <!-- placeholder-2 -->
         ${diff}
         <!-- placeholder-3 -->
-        <details${{ inputs.comment-pr-open-log-view == 'true' && ' open' || '' }}><summary>${summary}</br>
+        <details${{ inputs.expand-summary == 'true' && ' open' || '' }}><summary>${summary}</br>
 
         <!-- placeholder-4 -->
         ###### By ${handle}${{ github.triggering_actor }} at ${{ github.event.pull_request.updated_at || github.event.comment.created_at || github.event.head_commit.timestamp || github.event.merge_group.head_commit.timestamp }} [(view log)](${run_url}).
@@ -489,13 +489,13 @@ inputs:
     default: "always"
     description: "Add a PR comment: `always`, `on-change`, or `never` (e.g., `always`)."
     required: false
-  comment-pr-open-diff-view:
+  expand-diff:
     default: "false"
-    description: "Whether the PR comment should auto-open the short resource diff view's disclosure triangle (e.g., `false`)."
+    description: "Expand the collapsible diff output section (e.g., `false`)."
     required: false
-  comment-pr-open-log-view:
+  expand-summary:
     default: "false"
-    description: "Whether the PR comment should auto-open the detailed log view's disclosure triangle (e.g., `false`)."
+    description: "Expand the collapsible summary output section (e.g., `false`)."
     required: false
   format:
     default: "false"


### PR DESCRIPTION
This option will allow teams who prefer it, to draw more attention to the short resource diff and/or the detailed log views in the PR comment, to highlight potentially destructive changes more readily.

The default behavior of these new optional inputs matches the prior behavior, so there is no change for teams who do not opt in.