### PR TITLE
patch: label pr continue on error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -159,6 +159,7 @@ runs:
         ${{ inputs.tool }}${{ steps.arg.outputs.arg-chdir }} validate${args} 2> >(tee tf.console.txt) > >(tee tf.console.txt)
 
     - if: ${{ inputs.label-pr == 'true' && steps.identifier.outputs.pr != 0 && contains(fromJSON('["plan", "apply"]'), inputs.command) }}
+      continue-on-error: true
       shell: bash
       run: |
         # Label PR.


### PR DESCRIPTION
Resolves #452.

### Fixed

- Per recent [unannounced change](https://github.com/googleapis/release-please-action/issues/1105), GitHub API now requires `issues: write` permission in order to [create PR labels](https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#create-a-label). As a GitHub Action, we don't want to extend our access/footprint any more than needed, so this patch suppresses any error from the "Label PR" step until GitHub makes a concrete announcement.