### PR TITLE
feat: support github enterprise data residency for australia and european union (sweden, netherlands)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -237,7 +237,7 @@ runs:
           rm --force "$path"
         fi
 
-    - if: ${{ inputs.command == 'plan' && inputs.upload-plan == 'true' && github.server_url == 'https://github.com' }}
+    - if: ${{ inputs.command == 'plan' && inputs.upload-plan == 'true' && (github.server_url == 'https://github.com' || contains(github.server_url, '.ghe.com')) }}
       id: upload
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
@@ -246,7 +246,7 @@ runs:
         retention-days: ${{ inputs.retention-days }}
         overwrite: true
 
-    - if: ${{ inputs.command == 'plan' && inputs.upload-plan == 'true' && github.server_url != 'https://github.com' }}
+    - if: ${{ inputs.command == 'plan' && inputs.upload-plan == 'true' && !(github.server_url == 'https://github.com' || contains(github.server_url, '.ghe.com')) }}
       id: upload-v3
       uses: actions/upload-artifact@c24449f33cd45d4826c6702db7e49f7cdb9b551d # v3.2.1-node20
       with:


### PR DESCRIPTION
This fix allows the action to be run on the new data residency instances (https://github.com/newsroom/press-releases/data-residency-in-the-eu) which github offers for selected customers. New instances come with the following slug `COMPANY.ghe.com`, because of that, I've made an condition which further checks if the token provided has `ghe.com` in it's parameters.
Note, I've only tested these changes on the new `ghe.com` instance, not on a `github.com` one.

v4 upload
```bash
${{ inputs.command == 'plan' && inputs.upload-plan == 'true' && (github.server_url == 'https://github.com' || contains(github.server_url, '.ghe.com')) }}
```

v3 upload
```bash
${{ inputs.command == 'plan' && inputs.upload-plan == 'true' && !(github.server_url == 'https://github.com' || contains(github.server_url, '.ghe.com')) }}
```