### PR TITLE
fix: change counting logic for case of zero changes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -349,7 +349,7 @@ runs:
         # If "tf.diff.txt" exists, display it within a "diff" block, truncated for character limit.
         if [[ -s tf.diff.txt ]]; then
           # Get count of lines in "tf.diff.txt" which do not start with "# ".
-          diff_count=$(grep --invert-match '^# ' tf.diff.txt | wc --lines)
+          diff_count=$({ grep --invert-match '^# ' tf.diff.txt || true; } | wc --lines)
           if [[ $diff_count -eq 1 ]]; then diff_change="change"; else diff_change="changes"; fi
 
           # Parse diff of changes, truncated for character limit.


### PR DESCRIPTION
Prior to this PR,

In the case where a `tf.diff.txt` is generated, but it contains no changes (e.g. only moves and imports), then the `grep` that looks for lines not starting with `^# ` would find no lines at all, causing `grep` to return a non-zero exit code, which causes the CI/CD workflow to fail.

This PR fixes the issue by adding `|| true` to the relevant `grep`. The `true` command will output zero lines with a zero exit code, so it makes a good fallback here when the `grep` fails (because the `wc --lines` that follows will count zero lines).