### PR TITLE
chore: increase character limit for truncation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -285,8 +285,8 @@ runs:
         echo "command=$command" >> "$GITHUB_OUTPUT"
 
         # Parse the "tf.console.txt" file, truncated for character limit.
-        console=$(head --bytes=42000 tf.console.txt)
-        if [[ ${#console} -eq 42000 ]]; then console="${console}"$'\n…'; fi
+        console=$(head --bytes=174000 tf.console.txt)
+        if [[ ${#console} -eq 174000 ]]; then console="${console}"$'\n…'; fi
         echo "result<<EORESULTTFVIAPR"$'\n'"$console"$'\n'EORESULTTFVIAPR >> "$GITHUB_OUTPUT"
 
         # Parse the "tf.console.txt" file for the summary.
@@ -344,8 +344,8 @@ runs:
           if [[ $diff_count -eq 1 ]]; then diff_change="change"; else diff_change="changes"; fi
 
           # Parse diff of changes, truncated for character limit.
-          diff_truncated=$(head --bytes=24000 tf.diff.txt)
-          if [[ ${#diff_truncated} -eq 24000 ]]; then diff_truncated="${diff_truncated}"$'\n…'; fi
+          diff_truncated=$(head --bytes=84000 tf.diff.txt)
+          if [[ ${#diff_truncated} -eq 84000 ]]; then diff_truncated="${diff_truncated}"$'\n…'; fi
           echo "diff<<EODIFFTFVIAPR"$'\n'"$diff_truncated"$'\n'EODIFFTFVIAPR >> "$GITHUB_OUTPUT"
 
           diff="


### PR DESCRIPTION
Resolved #465.

### Improved

- #466 Expanded truncation scope of `diff`/`console` from 24000/42000 to 84000/174000 to make better use of a PR comment's 262144 (2^18) [character limit](https://github.com/dead-claudia/github-limits?tab=readme-ov-file#pr-body) (previously 65536 (2^16)).