### PR TITLE
fix: logic for `comment-pr` and `comment-method` options

### DIFF
--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         tool:
           - tofu
-          - terraform
+          # - terraform
         test:
           - pass_one
-          - pass_character_limit
-          - fail_data_source_error
-          - fail_format_diff
-          - fail_invalid_resource_type
+          # - pass_character_limit
+          # - fail_data_source_error
+          # - fail_format_diff
+          # - fail_invalid_resource_type
 
     steps:
       - name: Echo context

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -75,7 +75,7 @@ jobs:
           preserve-plan: true
           retention-days: 1
 
-          comment-pr: ${{ matrix.tool == 'tofu' && 'always' || 'never' }}
+          comment-pr: never
           hide-args: detailed-exitcode,lock,out,refresh
           tag-actor: never
 

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
 | Security | `token`             | Specify a GitHub token.</br>Default: `${{ github.token }}`                                                                                |
 | UI       | `expand-diff`       | Expand the collapsible diff section.</br>Default: `false`                                                                                 |
 | UI       | `expand-summary`    | Expand the collapsible summary section.</br>Default: `false`                                                                              |
-| UI       | `comment-pr`        | Add a PR comment: `always`, `on-change`, or `never`.<sup>4</sup></br>Default: `always`                                                    |
+| UI       | `comment-pr`        | Add a PR comment: `always`, `on-diff`, or `never`.<sup>4</sup></br>Default: `always`                                                      |
 | UI       | `comment-method`    | PR comment by: `update` existing comment or `recreate` and delete previous one.<sup>5</sup></br>Default: `update`                         |
-| UI       | `tag-actor`         | Tag the workflow triggering actor: `always`, `on-change`, or `never`.<sup>4</sup></br>Default: `always`                                   |
+| UI       | `tag-actor`         | Tag the workflow triggering actor: `always`, `on-diff`, or `never`.<sup>4</sup></br>Default: `always`                                     |
 | UI       | `hide-args`         | Hide comma-separated list of CLI arguments from the command input.<sup>6</sup></br>Default: `detailed-exitcode,parallelism,lock,out,var=` |
 | UI       | `show-args`         | Show comma-separated list of CLI arguments in the command input.<sup>6</sup></br>Default: `workspace`                                     |
 
@@ -196,7 +196,7 @@ All supported CLI argument inputs are [listed below](#arguments) with accompanyi
     To separately run checks and/or generate outputs only, `command: init` can be used.</br></br>
 1. Originally intended for `merge_group` event trigger, `plan-parity: true` input helps to prevent stale apply within a series of workflow runs when merging multiple PRs.</br></br>
 1. The secret string input for `plan-encrypt` can be of any length, as long as it's consistent between encryption (plan) and decryption (apply).</br></br>
-1. The `on-change` option is true when the exit code of the last TF command is non-zero (ensure `terraform_wrapper`/`tofu_wrapper` is set to `false`).</br></br>
+1. The `on-diff` option is true when the exit code of the last TF command is non-zero (ensure `terraform_wrapper`/`tofu_wrapper` is set to `false`).</br></br>
 1. The default behavior of `comment-method` is to update the existing PR comment with the latest plan/apply output, making it easy to track changes over time through the comment's revision history.</br></br>
   [![PR comment revision history comparing plan and apply outputs.](/.github/assets/revisions.png)](https://raw.githubusercontent.com/op5dev/tf-via-pr/refs/heads/main/.github/assets/revisions.png "View full-size image.")</br></br>
 1. It can be desirable to hide certain arguments from the last run command input to prevent exposure in the PR comment (e.g., sensitive `arg-var` values). Conversely, it can be desirable to show other arguments even if they are not in last run command input (e.g., `arg-workspace` or `arg-backend-config` selection).

--- a/action.yml
+++ b/action.yml
@@ -263,7 +263,7 @@ runs:
     - id: post
       if: ${{ !cancelled() && steps.identifier.outcome == 'success' && contains(fromJSON('["plan", "apply", "init"]'), inputs.command) }}
       env:
-        exitcode: ${{ steps.apply.outputs.exit_code || steps.plan.outputs.exit_code || steps.validate.outputs.exit_code || steps.workspace.outputs.exit_code || steps.initialize.outputs.exit_code || steps.format.outputs.exit_code }}
+        exitcode: ${{ steps.apply.outputs.exit_code || steps.plan.outputs.exit_code || steps.validate.outputs.exit_code || steps.initialize.outputs.exit_code || steps.format.outputs.exit_code }}
         GH_MATRIX: ${{ toJSON(matrix) }}
         PRESERVE_PLAN: ${{ inputs.preserve-plan }}
       shell: bash
@@ -272,13 +272,13 @@ runs:
         # Parse the "tf.command.txt" file.
         command=$(cat tf.command.txt)
 
-        # Remove each comma-delemited "hide-args" argument from the command.
+        # Remove each comma-delimited "hide-args" argument from the command.
         IFS=',' read -ra hide_args <<< "${{ inputs.hide-args }}"
         for arg in "${hide_args[@]}"; do
           command=$(echo "$command" | grep --invert-match "^ -${arg}" || true)
         done
 
-        # Conversely, show each comma-delemited "show-args" argument in the command.
+        # Conversely, show each comma-delimited "show-args" argument in the command.
         command_append=""
         IFS=',' read -ra show_args <<< "${{ inputs.show-args }}"
         for arg in "${show_args[@]}"; do
@@ -367,13 +367,11 @@ runs:
         # Set flags for creating PR comment and tagging actor.
         create_comment=""
         tag_actor=""
-        if [[ $exitcode -ne 0 ]]; then
-          if [[ "${{ inputs.comment-pr }}" == "on-change" ]]; then create_comment="true"; fi
-          if [[ "${{ inputs.tag-actor }}" == "on-change" ]]; then tag_actor="true"; fi
+        if [[ "${{ inputs.tag-actor }}" == "always" || "${{ inputs.tag-actor }}" == "true" ]]; then
+          tag_actor="@"
+        elif [[ ("${{ inputs.tag-actor }}" == "on-diff" || "${{ inputs.tag-actor }}" == "on-change") && "$exitcode" -ne 0 ]]; then
+          tag_actor="@"
         fi
-        if [[ "${{ inputs.comment-pr }}" == "always" || "${{ inputs.comment-pr }}" == "true" ]]; then create_comment="true"; fi
-        if [[ "${{ inputs.tag-actor }}" == "always" || "${{ inputs.tag-actor }}" == "true" ]]; then tag_actor="true"; fi
-        if [[ "$tag_actor" == "true" ]]; then handle="@"; else handle=""; fi
 
         # Collate body content.
         body=$(cat <<EOBODYTFVIAPR
@@ -387,7 +385,7 @@ runs:
         <details${{ inputs.expand-summary == 'true' && ' open' || '' }}><summary>${summary}</br>
 
         <!-- placeholder-4 -->
-        ###### By ${handle}${{ github.triggering_actor }} at ${{ github.event.pull_request.updated_at || github.event.comment.created_at || github.event.head_commit.timestamp || github.event.merge_group.head_commit.timestamp }} [(view log)](${run_url}).
+        ###### By ${tag_actor}${{ github.triggering_actor }} at ${{ github.event.pull_request.updated_at || github.event.comment.created_at || github.event.head_commit.timestamp || github.event.merge_group.head_commit.timestamp }} [(view log)](${run_url}).
         </summary>
 
         \`\`\`${syntax}
@@ -404,38 +402,6 @@ runs:
         echo "$body" >> $GITHUB_STEP_SUMMARY
         echo "comment_body<<EOCOMMENTTFVIAPR"$'\n'"$body"$'\n'EOCOMMENTTFVIAPR >> "$GITHUB_OUTPUT"
 
-        # Post PR comment if configured and PR exists.
-        if [[ "$create_comment" == "true" && "${{ steps.identifier.outputs.pr }}" != "0" ]]; then
-          # Check if the PR contains a bot comment with the same identifier.
-          list_comments=$(gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method GET --paginate)
-          bot_comment=$(echo "$list_comments" | jq --raw-output --arg identifier "${{ steps.identifier.outputs.name }}" '.[] | select(.user.type == "Bot") | select(.body | contains($identifier)) | .id' | tail -n 1)
-
-          if [[ -n "$bot_comment" ]]; then
-            if [[ "${{ inputs.comment-method }}" == "recreate" ]]; then
-              # Delete previous comment before posting a new one.
-              gh api /repos/${{ github.repository }}/issues/comments/${bot_comment} --header "$GH_API" --method DELETE
-              pr_comment=$(gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method POST --field "body=${body}")
-              echo "comment_id=$(echo "$pr_comment" | jq --raw-output '.id')" >> "$GITHUB_OUTPUT"
-            elif [[ "${{ inputs.comment-method }}" == "update" ]]; then
-              # Update existing comment.
-              pr_comment=$(gh api /repos/${{ github.repository }}/issues/comments/${bot_comment} --header "$GH_API" --method PATCH --field "body=${body}")
-              echo "comment_id=$(echo "$pr_comment" | jq --raw-output '.id')" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            # Post new comment.
-            pr_comment=$(gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method POST --field "body=${body}")
-            echo "comment_id=$(echo "$pr_comment" | jq --raw-output '.id')" >> "$GITHUB_OUTPUT"
-          fi
-        elif [[ "${{ inputs.comment-pr }}" == "on-change" && "${{ steps.identifier.outputs.pr }}" != "0" ]]; then
-          # Delete previous comment due to no changes.
-          list_comments=$(gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method GET --paginate)
-          bot_comment=$(echo "$list_comments" | jq --raw-output --arg identifier "${{ steps.identifier.outputs.name }}" '.[] | select(.user.type == "Bot") | select(.body | contains($identifier)) | .id' | tail -n 1)
-
-          if [[ -n "$bot_comment" ]]; then
-            gh api /repos/${{ github.repository }}/issues/comments/${bot_comment} --header "$GH_API" --method DELETE
-          fi
-        fi
-
         # Optionally delete the plan file.
         if [[ "$PRESERVE_PLAN" != "true" ]]; then
           rm --force "${{ format('{0}{1}tfplan', inputs.arg-chdir || inputs.working-directory, (inputs.arg-chdir || inputs.working-directory) && '/' || '') }}"
@@ -443,6 +409,43 @@ runs:
 
         # Clean up files.
         rm --force tf.command.txt tf.console.txt tf.diff.txt
+
+        # Check if the PR contains a bot comment with the same identifier.
+        list_comments=$(gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method GET --paginate)
+        bot_comment=$(echo "$list_comments" | jq --raw-output --arg identifier "${{ steps.identifier.outputs.name }}" '.[] | select(.user.type == "Bot") | select(.body | contains($identifier)) | .id' | tail -n 1)
+
+        # Determine if a PR comment should be created.
+        if [[ "${{ inputs.comment-pr }}" == "always" && "${{ steps.identifier.outputs.pr }}" -ne 0 ]]; then
+          create_comment="true"
+        elif [[ ("${{ inputs.comment-pr }}" == "on-diff" || "${{ inputs.comment-pr }}" == "on-change") && "$exitcode" -ne 0 && "${{ steps.identifier.outputs.pr }}" -ne 0]]; then
+          create_comment="true"
+        elif [[ ("${{ inputs.comment-pr }}" == "on-diff" || "${{ inputs.comment-pr }}" == "on-change") && "$exitcode" -eq 0 && -n "$bot_comment"]]; then
+          gh api /repos/${{ github.repository }}/issues/comments/${bot_comment} --header "$GH_API" --method DELETE
+          exit 0
+        fi
+
+        # Exit early if no comment is needed.
+        if [[ "$create_comment" != "true" ]]; then
+          exit 0
+        fi
+
+        # Create PR comment based on configuration and existing comment.
+        if [[ -n "$bot_comment" ]]; then
+          if [[ "${{ inputs.comment-method }}" == "update" ]]; then
+            # Update existing comment.
+            pr_comment=$(gh api /repos/${{ github.repository }}/issues/comments/${bot_comment} --header "$GH_API" --method PATCH --field "body=${body}")
+            echo "comment_id=$(echo "$pr_comment" | jq --raw-output '.id')" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ inputs.comment-method }}" == "recreate" ]]; then
+            # Delete previous comment before posting a new one.
+            gh api /repos/${{ github.repository }}/issues/comments/${bot_comment} --header "$GH_API" --method DELETE
+            pr_comment=$(gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method POST --field "body=${body}")
+            echo "comment_id=$(echo "$pr_comment" | jq --raw-output '.id')" >> "$GITHUB_OUTPUT"
+          fi
+        else
+          # Post new comment.
+          pr_comment=$(gh api /repos/${{ github.repository }}/issues/${{ steps.identifier.outputs.pr }}/comments --header "$GH_API" --method POST --field "body=${body}")
+          echo "comment_id=$(echo "$pr_comment" | jq --raw-output '.id')" >> "$GITHUB_OUTPUT"
+        fi
 
 outputs:
   check-id:
@@ -462,7 +465,7 @@ outputs:
     value: ${{ steps.post.outputs.diff }}
   exitcode:
     description: "Exit code of the last TF command."
-    value: ${{ steps.apply.outputs.exit_code || steps.plan.outputs.exit_code || steps.validate.outputs.exit_code || steps.workspace.outputs.exit_code || steps.initialize.outputs.exit_code || steps.format.outputs.exit_code }}
+    value: ${{ steps.apply.outputs.exit_code || steps.plan.outputs.exit_code || steps.validate.outputs.exit_code || steps.initialize.outputs.exit_code || steps.format.outputs.exit_code }}
   identifier:
     description: "Unique name of the workflow run and artifact."
     value: ${{ steps.identifier.outputs.name }}
@@ -497,7 +500,7 @@ inputs:
     required: false
   comment-pr:
     default: "always"
-    description: "Add a PR comment: `always`, `on-change`, or `never` (e.g., `always`)."
+    description: "Add a PR comment: `always`, `on-diff`, or `never` (e.g., `always`)."
     required: false
   expand-diff:
     default: "false"
@@ -545,7 +548,7 @@ inputs:
     required: false
   tag-actor:
     default: "always"
-    description: "Tag the workflow triggering actor: `always`, `on-change`, or `never` (e.g., `always`)."
+    description: "Tag the workflow triggering actor: `always`, `on-diff`, or `never` (e.g., `always`)."
     required: false
   token:
     default: ${{ github.token }}


### PR DESCRIPTION
### Deprecated

- For `comment-pr` and `tag-actor` arguments, renamed "on-change" option to "on-diff" instead to better reflect the condition upon which they're `true`, when [detailed-exitcode](https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode) is either non-empty diff or error.